### PR TITLE
Sort Python statistics in reverse chronological order; add non-EOL plot

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,9 +80,9 @@
             <p>This section shows consumer readiness for a given policy.</p>
             <p>
                 Before Python 3.10, support for a policy was a combination of glibc version (as denoted in the policy name for PEP600)
-                and pip version. As of Python 3.10, the default pip is always capable of PEP 600 based manylinux wheels.
-                Before that, the pip version available without upgrading it depends on either the Python version
-                and/or the linux distribution being used. At least the Python version is explicit in this section.
+                and pip version. As of Python 3.10, the default pip is always capable of PEP600 based manylinux wheels.
+                Before that, the pip version available (without manually upgrading) depends on the Python version
+                and/or the Linux distribution being used. At least the Python version is explicit in this section.
             </p>
             <p>
                 All manylinux wheel downloads from <a href="https://pypi.org/">PyPI</a> using pip are analysed each day to compute those statistics.
@@ -90,7 +90,7 @@
             </p>
         </div>
         <div class="col-sm-6">
-            <h2 id="consumer-glibc-readiness-3.12">glibc readiness for Python 3.12</h2>
+            <h2 id="consumer-glibc-readiness-3.12">glibc readiness for Python 3.12 (preview)</h2>
             <div><div id="consumer-glibc-readiness-3.12-plot" class="plotly-graph-div"></div></div>
         </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -242,8 +242,8 @@
         $("#package_count").text(data.package_count)
         load_plot("consumer-python-version-plot", data.index, data.python_version, true, "%", "normal", false);
         load_plot("consumer-glibc-version-plot", data.index, data.glibc_version, true, "%", "reversed", true);
-        load_plot("consumer-python-noneol-version-plot", data.index, data.python_version, true, "%", "normal", false);
-        load_plot("consumer-glibc-noneol-version-plot", data.index, data.glibc_version, true, "%", "reversed", true);
+        load_plot("consumer-python-noneol-version-plot", data.index, data.python_version_noneol, true, "%", "normal", false);
+        load_plot("consumer-glibc-noneol-version-plot", data.index, data.glibc_version_noneol, true, "%", "reversed", true);
         load_plot("consumer-policy-readiness-2.7-plot", data.index, data.policy_readiness["2.7"], true, "%", "reversed", true);
         load_plot("consumer-glibc-readiness-2.7-plot", data.index, data.glibc_readiness["2.7"], true, "%", "reversed", true);
         load_plot("consumer-policy-readiness-3.5-plot", data.index, data.policy_readiness["3.5"], true, "%", "reversed", true);

--- a/index.html
+++ b/index.html
@@ -256,11 +256,8 @@
         load_plot("consumer-glibc-readiness-3.8-plot", data.index, data.glibc_readiness["3.8"], true, "%", "reversed", true);
         load_plot("consumer-policy-readiness-3.9-plot", data.index, data.policy_readiness["3.9"], true, "%", "reversed", true);
         load_plot("consumer-glibc-readiness-3.9-plot", data.index, data.glibc_readiness["3.9"], true, "%", "reversed", true);
-        load_plot("consumer-policy-readiness-3.10-plot", data.index, data.policy_readiness["3.10"], true, "%", "reversed", true);
         load_plot("consumer-glibc-readiness-3.10-plot", data.index, data.glibc_readiness["3.10"], true, "%", "reversed", true);
-        load_plot("consumer-policy-readiness-3.11-plot", data.index, data.policy_readiness["3.11"], true, "%", "reversed", true);
         load_plot("consumer-glibc-readiness-3.11-plot", data.index, data.glibc_readiness["3.11"], true, "%", "reversed", true);
-        load_plot("consumer-policy-readiness-3.12-plot", data.index, data.policy_readiness["3.12"], true, "%", "reversed", true);
         load_plot("consumer-glibc-readiness-3.12-plot", data.index, data.glibc_readiness["3.12"], true, "%", "reversed", true);
     }
     $.getJSON("producer-data.json")

--- a/index.html
+++ b/index.html
@@ -66,92 +66,12 @@
     </div>
     <div class="row">
         <div class="col-sm-6">
-            <h2 id="consumer-policy-readiness-2.7">Policy readiness for python 2.7</h2>
-            <div><div id="consumer-policy-readiness-2.7-plot" class="plotly-graph-div"></div></div>
+            <h2 id="consumer-python-version">Python version (non-EOL)</h2>
+            <div><div id="consumer-python-noneol-version-plot" class="plotly-graph-div"></div></div>
         </div>
         <div class="col-sm-6">
-            <h2 id="consumer-glibc-readiness-2.7">glibc readiness for python 2.7</h2>
-            <div><div id="consumer-glibc-readiness-2.7-plot" class="plotly-graph-div"></div></div>
-        </div>
-    </div>
-    <div class="row">
-        <div class="col-sm-6">
-            <h2 id="consumer-policy-readiness-3.5">Policy readiness for python 3.5</h2>
-            <div><div id="consumer-policy-readiness-3.5-plot" class="plotly-graph-div"></div></div>
-        </div>
-        <div class="col-sm-6">
-            <h2 id="consumer-glibc-readiness-3.5">glibc readiness for python 3.5</h2>
-            <div><div id="consumer-glibc-readiness-3.5-plot" class="plotly-graph-div"></div></div>
-        </div>
-    </div>
-    <div class="row">
-        <div class="col-sm-6">
-            <h2 id="consumer-policy-readiness-3.6">Policy readiness for python 3.6</h2>
-            <div><div id="consumer-policy-readiness-3.6-plot" class="plotly-graph-div"></div></div>
-        </div>
-        <div class="col-sm-6">
-            <h2 id="consumer-glibc-readiness-3.6">glibc readiness for python 3.6</h2>
-            <div><div id="consumer-glibc-readiness-3.6-plot" class="plotly-graph-div"></div></div>
-        </div>
-    </div>
-    <div class="row">
-        <div class="col-sm-6">
-            <h2 id="consumer-policy-readiness-3.7">Policy readiness for python 3.7</h2>
-            <div><div id="consumer-policy-readiness-3.7-plot" class="plotly-graph-div"></div></div>
-        </div>
-        <div class="col-sm-6">
-            <h2 id="consumer-glibc-readiness-3.7">glibc readiness for python 3.7</h2>
-            <div><div id="consumer-glibc-readiness-3.7-plot" class="plotly-graph-div"></div></div>
-        </div>
-    </div>
-    <div class="row">
-        <div class="col-sm-6">
-            <h2 id="consumer-policy-readiness-3.8">Policy readiness for python 3.8</h2>
-            <div><div id="consumer-policy-readiness-3.8-plot" class="plotly-graph-div"></div></div>
-        </div>
-        <div class="col-sm-6">
-            <h2 id="consumer-glibc-readiness-3.8">glibc readiness for python 3.8</h2>
-            <div><div id="consumer-glibc-readiness-3.8-plot" class="plotly-graph-div"></div></div>
-        </div>
-    </div>
-    <div class="row">
-        <div class="col-sm-6">
-            <h2 id="consumer-policy-readiness-3.9">Policy readiness for python 3.9</h2>
-            <div><div id="consumer-policy-readiness-3.9-plot" class="plotly-graph-div"></div></div>
-        </div>
-        <div class="col-sm-6">
-            <h2 id="consumer-glibc-readiness-3.9">glibc readiness for python 3.9</h2>
-            <div><div id="consumer-glibc-readiness-3.9-plot" class="plotly-graph-div"></div></div>
-        </div>
-    </div>
-    <div class="row">
-        <div class="col-sm-6">
-            <h2 id="consumer-policy-readiness-3.10">Policy readiness for python 3.10</h2>
-            <div><div id="consumer-policy-readiness-3.10-plot" class="plotly-graph-div"></div></div>
-        </div>
-        <div class="col-sm-6">
-            <h2 id="consumer-glibc-readiness-3.10">glibc readiness for python 3.10</h2>
-            <div><div id="consumer-glibc-readiness-3.10-plot" class="plotly-graph-div"></div></div>
-        </div>
-    </div>
-    <div class="row">
-        <div class="col-sm-6">
-            <h2 id="consumer-policy-readiness-3.11">Policy readiness for python 3.11</h2>
-            <div><div id="consumer-policy-readiness-3.11-plot" class="plotly-graph-div"></div></div>
-        </div>
-        <div class="col-sm-6">
-            <h2 id="consumer-glibc-readiness-3.11">glibc readiness for python 3.11</h2>
-            <div><div id="consumer-glibc-readiness-3.11-plot" class="plotly-graph-div"></div></div>
-        </div>
-    </div>
-    <div class="row">
-        <div class="col-sm-6">
-            <h2 id="consumer-policy-readiness-3.12">Policy readiness for python 3.12</h2>
-            <div><div id="consumer-policy-readiness-3.12-plot" class="plotly-graph-div"></div></div>
-        </div>
-        <div class="col-sm-6">
-            <h2 id="consumer-glibc-readiness-3.12">glibc readiness for python 3.12</h2>
-            <div><div id="consumer-glibc-readiness-3.12-plot" class="plotly-graph-div"></div></div>
+            <h2 id="consumer-glibc-version">glibc version</h2>
+            <div><div id="consumer-glibc-noneol-version-plot" class="plotly-graph-div"></div></div>
         </div>
     </div>
     <div class="row">
@@ -159,14 +79,89 @@
             <h2 id="consumer-about">About consumer statistics</h2>
             <p>This section shows consumer readiness for a given policy.</p>
             <p>
-                Support for a policy is a combination of glibc version (as denoted in the policy name for PEP600)
-                and pip version. The pip version available without upgrading it depends on either the python version
-                and/or the linux distribution being used. At least the python version is explicit in this section.
+                Before Python 3.10, support for a policy was a combination of glibc version (as denoted in the policy name for PEP600)
+                and pip version. As of Python 3.10, the default pip is always capable of PEP 600 based manylinux wheels.
+                Before that, the pip version available without upgrading it depends on either the Python version
+                and/or the linux distribution being used. At least the Python version is explicit in this section.
             </p>
             <p>
                 All manylinux wheel downloads from <a href="https://pypi.org/">PyPI</a> using pip are analysed each day to compute those statistics.
                 The data set is smoothed using a 1-month sliding window algorithm.
             </p>
+        </div>
+        <div class="col-sm-6">
+            <h2 id="consumer-glibc-readiness-3.12">glibc readiness for Python 3.12</h2>
+            <div><div id="consumer-glibc-readiness-3.12-plot" class="plotly-graph-div"></div></div>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-sm-6">
+            <h2 id="consumer-glibc-readiness-3.11">glibc readiness for Python 3.11</h2>
+            <div><div id="consumer-glibc-readiness-3.11-plot" class="plotly-graph-div"></div></div>
+        </div>
+        <div class="col-sm-6">
+            <h2 id="consumer-glibc-readiness-3.10">glibc readiness for Python 3.10</h2>
+            <div><div id="consumer-glibc-readiness-3.10-plot" class="plotly-graph-div"></div></div>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-sm-6">
+            <h2 id="consumer-policy-readiness-3.9">Policy readiness for Python 3.9</h2>
+            <div><div id="consumer-policy-readiness-3.9-plot" class="plotly-graph-div"></div></div>
+        </div>
+        <div class="col-sm-6">
+            <h2 id="consumer-glibc-readiness-3.9">glibc readiness for Python 3.9</h2>
+            <div><div id="consumer-glibc-readiness-3.9-plot" class="plotly-graph-div"></div></div>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-sm-6">
+            <h2 id="consumer-policy-readiness-3.8">Policy readiness for Python 3.8</h2>
+            <div><div id="consumer-policy-readiness-3.8-plot" class="plotly-graph-div"></div></div>
+        </div>
+        <div class="col-sm-6">
+            <h2 id="consumer-glibc-readiness-3.8">glibc readiness for Python 3.8</h2>
+            <div><div id="consumer-glibc-readiness-3.8-plot" class="plotly-graph-div"></div></div>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-sm-6">
+            <h2 id="consumer-policy-readiness-3.7">Policy readiness for Python 3.7</h2>
+            <div><div id="consumer-policy-readiness-3.7-plot" class="plotly-graph-div"></div></div>
+        </div>
+        <div class="col-sm-6">
+            <h2 id="consumer-glibc-readiness-3.7">glibc readiness for Python 3.7</h2>
+            <div><div id="consumer-glibc-readiness-3.7-plot" class="plotly-graph-div"></div></div>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-sm-6">
+            <h2 id="consumer-policy-readiness-3.6">Policy readiness for Python 3.6 (EOL)</h2>
+            <div><div id="consumer-policy-readiness-3.6-plot" class="plotly-graph-div"></div></div>
+        </div>
+        <div class="col-sm-6">
+            <h2 id="consumer-glibc-readiness-3.6">glibc readiness for Python 3.6 (EOL)</h2>
+            <div><div id="consumer-glibc-readiness-3.6-plot" class="plotly-graph-div"></div></div>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-sm-6">
+            <h2 id="consumer-policy-readiness-3.5">Policy readiness for Python 3.5 (EOL)</h2>
+            <div><div id="consumer-policy-readiness-3.5-plot" class="plotly-graph-div"></div></div>
+        </div>
+        <div class="col-sm-6">
+            <h2 id="consumer-glibc-readiness-3.5">glibc readiness for Python 3.5 (EOL)</h2>
+            <div><div id="consumer-glibc-readiness-3.5-plot" class="plotly-graph-div"></div></div>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-sm-6">
+            <h2 id="consumer-policy-readiness-2.7">Policy readiness for Python 2.7 (EOL)</h2>
+            <div><div id="consumer-policy-readiness-2.7-plot" class="plotly-graph-div"></div></div>
+        </div>
+        <div class="col-sm-6">
+            <h2 id="consumer-glibc-readiness-2.7">glibc readiness for Python 2.7 (EOL)</h2>
+            <div><div id="consumer-glibc-readiness-2.7-plot" class="plotly-graph-div"></div></div>
         </div>
     </div>
     <div class="row">
@@ -186,7 +181,7 @@
         </div>
     </div>
     <footer>
-        <p class="footer">This is not an official website, just a nice visual way to measure progress. To see the authoritative guide on wheels and other aspects of python packaging, see the <a href="https://packaging.python.org">Python Packaging User Guide</a>.</p>
+        <p class="footer">This is not an official website, just a nice visual way to measure progress. To see the authoritative guide on wheels and other aspects of Python packaging, see the <a href="https://packaging.python.org">Python Packaging User Guide</a>.</p>
         <p class="footer">Last updated <span id="last_update">never</span>. (Updated daily.)</p>
         <a class="github-fork-ribbon" href="https://github.com/mayeut/manylinux-timeline" target="_blank" data-ribbon="Fork me on GitHub" title="Fork me on GitHub">Fork me on GitHub</a>
     </footer>
@@ -247,6 +242,8 @@
         $("#package_count").text(data.package_count)
         load_plot("consumer-python-version-plot", data.index, data.python_version, true, "%", "normal", false);
         load_plot("consumer-glibc-version-plot", data.index, data.glibc_version, true, "%", "reversed", true);
+        load_plot("consumer-python-noneol-version-plot", data.index, data.python_version, true, "%", "normal", false);
+        load_plot("consumer-glibc-noneol-version-plot", data.index, data.glibc_version, true, "%", "reversed", true);
         load_plot("consumer-policy-readiness-2.7-plot", data.index, data.policy_readiness["2.7"], true, "%", "reversed", true);
         load_plot("consumer-glibc-readiness-2.7-plot", data.index, data.glibc_readiness["2.7"], true, "%", "reversed", true);
         load_plot("consumer-policy-readiness-3.5-plot", data.index, data.policy_readiness["3.5"], true, "%", "reversed", true);

--- a/update_consumer_stats.py
+++ b/update_consumer_stats.py
@@ -245,7 +245,14 @@ def update(path: Path, start: datetime, end: datetime):
     out["glibc_version"] = glibc_version
 
     python_versions_eol = ["2.7", "3.5", "3.6"]
-    python_versions = python_versions_eol + ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+    python_versions = python_versions_eol + [
+        "3.7",
+        "3.8",
+        "3.9",
+        "3.10",
+        "3.11",
+        "3.12",
+    ]
     python_version = dict[str, Union[list[str], list[float]]]()
     python_version_noneol = dict[str, Union[list[str], list[float]]]()
     policy_readiness = dict[str, dict[str, Union[list[str], list[float]]]]()
@@ -317,8 +324,12 @@ def update(path: Path, start: datetime, end: datetime):
                 stats.append(float(f"{100.0 * value:.2f}"))
             glibc_readiness_ver[versions[0]] = stats
 
-    python_version_noneol = {k: v for k, v in python_version.items() if k not in python_versions_eol}
-    glibc_readiness_noneol = {k: v for k, v in glibc_readiness.items() if k not in python_versions_eol}
+    python_version_noneol = {
+        k: v for k, v in python_version.items() if k not in python_versions_eol
+    }
+    glibc_readiness_noneol = {
+        k: v for k, v in glibc_readiness.items() if k not in python_versions_eol
+    }
 
     out["python_version"] = python_version
     out["python_version_noneol"] = python_version_noneol

--- a/update_consumer_stats.py
+++ b/update_consumer_stats.py
@@ -244,10 +244,13 @@ def update(path: Path, start: datetime, end: datetime):
         glibc_version[versions[0]] = stats
     out["glibc_version"] = glibc_version
 
-    python_versions = ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+    python_versions_eol = ["2.7", "3.5", "3.6"]
+    python_versions = python_versions_eol + ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
     python_version = dict[str, Union[list[str], list[float]]]()
+    python_version_noneol = dict[str, Union[list[str], list[float]]]()
     policy_readiness = dict[str, dict[str, Union[list[str], list[float]]]]()
     glibc_readiness = dict[str, dict[str, Union[list[str], list[float]]]]()
+    glibc_readiness_noneol = dict[str, dict[str, Union[list[str], list[float]]]]()
     python_version["keys"] = python_versions
     for version in python_versions:
         stats = []
@@ -314,9 +317,15 @@ def update(path: Path, start: datetime, end: datetime):
                 stats.append(float(f"{100.0 * value:.2f}"))
             glibc_readiness_ver[versions[0]] = stats
 
+    python_version_noneol = {k: v for k, v in python_version.items() if k not in python_versions_eol}
+    glibc_readiness_noneol = {k: v for k, v in glibc_readiness.items() if k not in python_versions_eol}
+
     out["python_version"] = python_version
+    out["python_version_noneol"] = python_version_noneol
     out["policy_readiness"] = policy_readiness
+    # no need for noneol version of policy_readiness
     out["glibc_readiness"] = glibc_readiness
+    out["glibc_readiness_noneol"] = glibc_readiness_noneol
 
     with open(utils.CONSUMER_DATA_PATH, "w") as f:
         json.dump(out, f, separators=(",", ":"))


### PR DESCRIPTION
Trying to address #441.

~I don't yet know how I should add the calculation for the non-EOL statistics.~

Should be good now

Closes #441