### PR TITLE
clarify what "non-EOL" refers to for glibc plots

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,7 +60,7 @@
             <div><div id="consumer-python-version-plot" class="plotly-graph-div"></div></div>
         </div>
         <div class="col-sm-6">
-            <h2 id="consumer-glibc-version">glibc version (All)</h2>
+            <h2 id="consumer-glibc-version">glibc version (across all Python versions)</h2>
             <div><div id="consumer-glibc-version-plot" class="plotly-graph-div"></div></div>
         </div>
     </div>
@@ -70,7 +70,7 @@
             <div><div id="consumer-python-version-plot-non-eol" class="plotly-graph-div"></div></div>
         </div>
         <div class="col-sm-6">
-            <h2 id="consumer-glibc-version-non-eol">glibc version (non-EOL)</h2>
+            <h2 id="consumer-glibc-version-non-eol">glibc version (across non-EOL Python versions)</h2>
             <div><div id="consumer-glibc-version-plot-non-eol" class="plotly-graph-div"></div></div>
         </div>
     </div>


### PR DESCRIPTION
Otherwise the brackets in `glibc version (All)` / `glibc version (non-EOL)` could very easily be misinterpreted to be referring to the glibc versions.

CC @mayeut 